### PR TITLE
Add deployment instructions for /site

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,20 @@
+# Deploying the `/site` directory
+
+The `/site` folder contains static HTML, CSS, and JavaScript files. You can publish
+this folder with services like GitHub Pages or Netlify.
+
+## GitHub Pages
+1. Create a branch named `gh-pages` or use GitHub's Pages settings to serve the
+   `/site` directory.
+2. Push the contents of `/site` to the `gh-pages` branch or configure the
+   `gh-pages` branch as the Pages source.
+3. Visit your GitHub Pages URL to see the deployed site.
+
+## Netlify
+1. Sign in to Netlify and create a new site from Git.
+2. Select this repository and set the publish directory to `site`.
+3. Deploy the site. Netlify will host the contents of the `/site` folder.
+
+## Verifying locally
+Open `site/index.html` in a web browser to verify the site renders as expected
+before deploying.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # 4
+
+This repository demonstrates a simple static site in the `/site` directory.
+See [DEPLOY.md](DEPLOY.md) for instructions on how to deploy it.


### PR DESCRIPTION
## Summary
- clarify where to find deployment instructions in README
- add DEPLOY.md explaining how to publish the `/site` folder using GitHub Pages or Netlify
- document verifying the site locally by opening `site/index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68558696e378833387dae55292cf8ebc