### PR TITLE
Fix site path info and add agent instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ This repository contains the source code for the 4th Down Decider, a web-based t
 ```
 /site
   index.html      # main page
-  css/            # styles
-  js/             # client-side logic
+  style.css       # styles
+  script.js       # client-side logic
 ```
 
-All functionality is implemented in the files under `/site/js` using client-side JavaScript.
+All functionality is implemented in `site/script.js` using client-side JavaScript.
 
 ## Contributing
 

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Use plain HTML, CSS, and JavaScript.
+- Keep all client-side files inside the `site` directory.
+- Start a local server with `serve site` when testing changes.
+- Record structural updates in `AGENT_LOG.md` with timestamps.


### PR DESCRIPTION
## Summary
- update README folder structure section
- document agent instructions in `agent.md`

## Testing
- `serve -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685588530144833380318f38fddf86ba