### PR TITLE
Expand placeholder backend modules

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -1,3 +1,6 @@
 ## 2024-05-08 - [18:00:00] Created user interface
 ## 2024-05-09 - [16:45:10] Implemented decision engine
 ## 2024-05-10 - [09:30:15] Deployed initial version
+## 2024-06-02 - [10:05:00] Added placeholder modules for config, logger, feature flags, API, and utilities
+
+## 2025-06-20 - [16:19:49] Created important backend changes with additional placeholder modules

--- a/site/modules/api.js
+++ b/site/modules/api.js
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview Fake API request utilities.
+ */
+
+/**
+ * Simulates an API request.
+ * @param {string} endpoint - The endpoint to request.
+ * @returns {Promise<object>} A promise that resolves with fake data.
+ */
+export function fakeRequest(endpoint) {
+  console.log(`Requesting: ${endpoint}`);
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({ status: 'ok', endpoint });
+    }, 300);
+  });
+}

--- a/site/modules/auth.js
+++ b/site/modules/auth.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Placeholder authentication module.
+ */
+
+/**
+ * Performs a fake login.
+ * @param {string} user - Username.
+ * @param {string} pass - Password.
+ * @returns {boolean}
+ */
+export function login(user, pass) {
+  console.log(`Logging in ${user}`);
+  return true;
+}
+
+/**
+ * Performs a fake logout.
+ */
+export function logout() {
+  console.log('Logging out');
+}

--- a/site/modules/cache.js
+++ b/site/modules/cache.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Fake caching utilities.
+ */
+
+const cacheStore = {};
+
+/**
+ * Stores a value in the fake cache.
+ * @param {string} key
+ * @param {*} value
+ */
+export function setCache(key, value) {
+  console.log(`Caching ${key}`);
+  cacheStore[key] = value;
+}
+
+/**
+ * Retrieves a value from the fake cache.
+ * @param {string} key
+ * @returns {*}
+ */
+export function getCache(key) {
+  console.log(`Getting cache for ${key}`);
+  return cacheStore[key];
+}

--- a/site/modules/configLoader.js
+++ b/site/modules/configLoader.js
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview Dummy config loader.
+ * Provides placeholder methods to mimic configuration retrieval.
+ */
+
+/**
+ * Loads the application configuration.
+ * @returns {{env: string, version: string}}
+ */
+export function loadConfig() {
+  console.log('Loading configuration');
+  return { env: 'development', version: '1.0.0' };
+}

--- a/site/modules/dbConnector.js
+++ b/site/modules/dbConnector.js
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview Fake database connector utilities.
+ */
+
+/**
+ * Connects to a pretend database.
+ */
+export function connect() {
+  console.log('Connecting to fake database');
+}
+
+/**
+ * Closes the pretend database connection.
+ */
+export function close() {
+  console.log('Closing fake database connection');
+}

--- a/site/modules/encryption.js
+++ b/site/modules/encryption.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Fake encryption utilities.
+ */
+
+/**
+ * Encrypts data in a fake manner.
+ * @param {string} data
+ * @returns {string}
+ */
+export function encrypt(data) {
+  console.log('Encrypting data');
+  return btoa(data);
+}
+
+/**
+ * Decrypts previously 'encrypted' data.
+ * @param {string} data
+ * @returns {string}
+ */
+export function decrypt(data) {
+  console.log('Decrypting data');
+  return atob(data);
+}

--- a/site/modules/features.js
+++ b/site/modules/features.js
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Feature flag toggler.
+ * Provides fake feature flag utilities.
+ */
+
+/**
+ * Checks if a feature is enabled.
+ * @param {string} flag - The feature flag name.
+ * @returns {boolean}
+ */
+export function isFeatureEnabled(flag) {
+  console.log(`Checking feature flag: ${flag}`);
+  return false;
+}
+
+/**
+ * Enables a feature flag.
+ * @param {string} flag - The feature flag to enable.
+ */
+export function enableFeature(flag) {
+  console.log(`Enabling feature: ${flag}`);
+}
+
+/**
+ * Disables a feature flag.
+ * @param {string} flag - The feature flag to disable.
+ */
+export function disableFeature(flag) {
+  console.log(`Disabling feature: ${flag}`);
+}

--- a/site/modules/logger.js
+++ b/site/modules/logger.js
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Fake logger module.
+ * Contains utilities for logging events.
+ */
+
+/**
+ * Logs an event message.
+ * @param {string} message - The message to log.
+ */
+export function logEvent(message) {
+  console.log('LOG:', message);
+}

--- a/site/modules/mailer.js
+++ b/site/modules/mailer.js
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Dummy mailer module.
+ */
+
+/**
+ * Sends a fake email.
+ * @param {string} to - Recipient.
+ * @param {string} subject - Email subject.
+ */
+export function sendMail(to, subject) {
+  console.log(`Sending mail to ${to} with subject: ${subject}`);
+}

--- a/site/modules/metrics.js
+++ b/site/modules/metrics.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Metrics collection placeholder.
+ */
+
+/**
+ * Records a fake metric event.
+ * @param {string} name - Metric name.
+ */
+export function recordMetric(name) {
+  console.log(`Recording metric: ${name}`);
+}

--- a/site/modules/notifier.js
+++ b/site/modules/notifier.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Notification utilities placeholder.
+ */
+
+/**
+ * Sends a fake notification.
+ * @param {string} message - Notification text.
+ */
+export function sendNotification(message) {
+  console.log(`Sending notification: ${message}`);
+}

--- a/site/modules/router.js
+++ b/site/modules/router.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Placeholder router for navigation.
+ */
+
+/**
+ * Navigates to a fake route.
+ * @param {string} path - Route path.
+ */
+export function navigate(path) {
+  console.log(`Navigating to ${path}`);
+}

--- a/site/modules/scheduler.js
+++ b/site/modules/scheduler.js
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Placeholder task scheduler.
+ */
+
+/**
+ * Queues a fake task.
+ * @param {Function} task - Task callback.
+ */
+export function schedule(task) {
+  console.log('Scheduling task');
+  setTimeout(task, 100);
+}

--- a/site/modules/utils.js
+++ b/site/modules/utils.js
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview General utilities.
+ */
+
+/**
+ * Sleeps for the specified duration.
+ * @param {number} ms - Duration in milliseconds.
+ * @returns {Promise<void>}
+ */
+export function sleep(ms) {
+  console.log(`Sleeping for ${ms}ms`);
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/site/modules/validator.js
+++ b/site/modules/validator.js
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview Dummy input validator.
+ */
+
+/**
+ * Validates an input string.
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function validate(value) {
+  console.log(`Validating: ${value}`);
+  return value.length > 0;
+}


### PR DESCRIPTION
## Summary
- add more placeholder scripts for db connector, auth, metrics, notifier, cache, scheduler, mailer, encryption, validator and router
- log important backend changes in AGENT_LOG

## Testing
- `npm install -g serve`
- `npx serve site` (terminated after confirming startup)


------
https://chatgpt.com/codex/tasks/task_e_68558909e5ac8333bbe5f6fbe3e4ef7f