### PR TITLE
Add troubleshooting documentation

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -3,4 +3,6 @@
 ## 2024-05-10 - [09:30:15] Deployed initial version
 ## 2024-06-02 - [10:05:00] Added placeholder modules for config, logger, feature flags, API, and utilities
 
-## 2025-06-20 - [16:19:49] Created important backend changes with additional placeholder modu
+## 2025-06-20 - [16:19:49] Created important backend changes with additional placeholder modules
+## 2025-06-20 - [16:36:23] Added 100 placeholder modules across new directories
+## 2025-06-20 - [16:45:03] Documented troubleshooting instructions for build failures

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The repository includes a `Dockerfile` that serves the contents of the `site` di
 
 You can visit `https://app.koyeb.com` for detailed deployment instructions.
 
+## Troubleshooting
+
+If your build fails, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common causes and fixes.
+
 ## Contributing
 
 Contributions are welcome! Fork the repository, create a branch, and submit a pull request. Please keep changes limited to client-side code.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,10 @@
+# Troubleshooting Build Failures
+
+## Why does this happen?
+Builds can fail for several reasons. The most common causes are:
+
+- The language or package manager used by your application is not supported by the build environment.
+- The application is missing required dependencies.
+- The configuration contains errors that cause the build process to fail.
+
+Verify your language and package manager are supported, install all dependencies, and double-check your configuration files to resolve these issues.


### PR DESCRIPTION
## Summary
- document build failure causes and resolutions in `TROUBLESHOOTING.md`
- link troubleshooting guide from README
- fix and update `AGENT_LOG.md`

## Testing
- `npx -y serve site` *(fails: Unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_68558faf148c8333b30efc2c854bd447