### PR TITLE
Add dummy agent modules for simulation

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -3,4 +3,5 @@
 ## 2024-05-10 - [09:30:15] Deployed initial version
 ## 2024-06-02 - [10:05:00] Added placeholder modules for config, logger, feature flags, API, and utilities
 
-## 2025-06-20 - [16:19:49] Created important backend changes with additional placeholder modu
+## 2025-06-20 - [16:19:49] Created important backend changes with additional placeholder modules
+## 2025-06-20 - [16:45:18] Added agent folders with placeholder JS files

--- a/site/agent01/config/envSettings.js
+++ b/site/agent01/config/envSettings.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 01 Environment Settings
+ * Holds configuration values such as feature flags.
+ */
+export const ENV = {
+  debug: false,
+  featureLevel: 'alpha'
+};

--- a/site/agent01/core/jobRunner.js
+++ b/site/agent01/core/jobRunner.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 01 Job Runner
+ * Spawns placeholder tasks in an async loop.
+ */
+export function runJobs(tasks) {
+  // Iterate through tasks without actual execution
+  tasks.forEach(t => t());
+}

--- a/site/agent01/core/mutexLocker.js
+++ b/site/agent01/core/mutexLocker.js
@@ -1,0 +1,12 @@
+/**
+ * Agent 01 Mutex Locker
+ * Demonstrates lock acquisition without real contention.
+ */
+export class Mutex {
+  lock() {
+    // Acquire fake lock
+  }
+  release() {
+    // Release fake lock
+  }
+}

--- a/site/agent01/features/analyticsPanel.js
+++ b/site/agent01/features/analyticsPanel.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 01 Analytics Panel
+ * Emits placeholder metrics for UI consumption.
+ */
+export function emitMetrics() {
+  // Push fake data to observer hooks
+}

--- a/site/agent01/features/betaFeature.js
+++ b/site/agent01/features/betaFeature.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 01 Beta Feature
+ * Represents a toggled experimental component.
+ */
+export const betaEnabled = true;

--- a/site/agent01/lib/endpointResolver.js
+++ b/site/agent01/lib/endpointResolver.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 01 Endpoint Resolver
+ * Resolves mocked service endpoints for test payload routing.
+ */
+export function resolveEndpoint(name) {
+  // Returns a fabricated URL for demonstration purposes
+  return `https://example.com/api/${name}`;
+}

--- a/site/agent01/lib/localeBinder.js
+++ b/site/agent01/lib/localeBinder.js
@@ -1,0 +1,9 @@
+/**
+ * Agent 01 Locale Binder
+ * Connects dummy locale data to the view layer.
+ */
+export const defaultLocale = 'en-US';
+export function bindLocale(locale = defaultLocale) {
+  // Simulate locale binding latency
+  return { locale };
+}

--- a/site/agent01/security/authShield.js
+++ b/site/agent01/security/authShield.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 01 Auth Shield
+ * Provides a stub authentication wrapper.
+ */
+export function verifyToken() {
+  // Bypass token verification for simulation
+  return true;
+}

--- a/site/agent01/utils/cacheBridge.js
+++ b/site/agent01/utils/cacheBridge.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 01 Cache Bridge
+ * Provides placeholder cache linking with minimal latency hooks.
+ */
+export function initCacheBridge() {
+  // Acquire dummy mutex for simulated caching
+}
+export const CACHE_BRIDGE_VERSION = '0.0.1';

--- a/site/agent01/utils/sessionPump.js
+++ b/site/agent01/utils/sessionPump.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 01 Session Pump
+ * Fake session handler that cycles through payloads.
+ */
+export function pumpSession(payload) {
+  // Placeholder to update session payload
+  return `pumped-${payload}`;
+}

--- a/site/agent02/config/serviceMap.js
+++ b/site/agent02/config/serviceMap.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 02 Service Map
+ * Lists placeholder services for integration tests.
+ */
+export const SERVICES = ['alpha', 'beta'];

--- a/site/agent02/core/dataWarehouse.js
+++ b/site/agent02/core/dataWarehouse.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 02 Data Warehouse
+ * Holds in-memory structures for sandboxing.
+ */
+export const store = {};

--- a/site/agent02/core/eventStreamer.js
+++ b/site/agent02/core/eventStreamer.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 02 Event Streamer
+ * Streams mock events for the pipeline.
+ */
+export function stream(events) {
+  events.forEach(e => e());
+}

--- a/site/agent02/features/notificationBus.js
+++ b/site/agent02/features/notificationBus.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 02 Notification Bus
+ * Dummy event bus for notifications.
+ */
+export function notify(message) {
+  console.log('notify:', message);
+}

--- a/site/agent02/features/profileInspector.js
+++ b/site/agent02/features/profileInspector.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 02 Profile Inspector
+ * Contains stubbed user profile analysis routines.
+ */
+export function inspect(profile) {
+  return { valid: true, profile };
+}

--- a/site/agent02/lib/metaDataProxy.js
+++ b/site/agent02/lib/metaDataProxy.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 02 Meta Data Proxy
+ * Placeholder proxy for metadata retrieval.
+ */
+export function fetchMeta(key) {
+  return { key };
+}

--- a/site/agent02/lib/payloadParser.js
+++ b/site/agent02/lib/payloadParser.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 02 Payload Parser
+ * Parses dummy payloads into objects.
+ */
+export function parsePayload(text) {
+  return { text };
+}

--- a/site/agent02/security/nonceFactory.js
+++ b/site/agent02/security/nonceFactory.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 02 Nonce Factory
+ * Generates ephemeral nonces without real randomness.
+ */
+export function createNonce() {
+  return Date.now().toString();
+}

--- a/site/agent02/utils/asyncStack.js
+++ b/site/agent02/utils/asyncStack.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 02 Async Stack
+ * Demonstrates queued asynchronous operations.
+ */
+export async function enqueue(task) {
+  // Immediate resolution for demonstration
+  return Promise.resolve(task);
+}

--- a/site/agent02/utils/cacheBridgeB.js
+++ b/site/agent02/utils/cacheBridgeB.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 02 Cache Bridge B
+ * Variant of cache bridge with placeholder latency metrics.
+ */
+export const bridgeLatency = 1;

--- a/site/agent03/config/themeCatalog.js
+++ b/site/agent03/config/themeCatalog.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 03 Theme Catalog
+ * Repository of stub theme configurations.
+ */
+export const themes = ['light', 'dark'];

--- a/site/agent03/core/appCore.js
+++ b/site/agent03/core/appCore.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 App Core
+ * Simplified core bootstrapping pipeline.
+ */
+export function bootstrap() {
+  // Placeholder bootstrap logic
+}

--- a/site/agent03/core/taskScheduler.js
+++ b/site/agent03/core/taskScheduler.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 Task Scheduler
+ * Coordinates scheduled dummy jobs.
+ */
+export function schedule(task) {
+  setTimeout(task, 0);
+}

--- a/site/agent03/features/liveConnector.js
+++ b/site/agent03/features/liveConnector.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 Live Connector
+ * Manages live updates with dummy events.
+ */
+export function connect() {
+  // No-op connection hook
+}

--- a/site/agent03/features/searchIndexer.js
+++ b/site/agent03/features/searchIndexer.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 Search Indexer
+ * Indexes data for mock search operations.
+ */
+export function index(data) {
+  // Simulate indexing delay
+}

--- a/site/agent03/lib/localeManager.js
+++ b/site/agent03/lib/localeManager.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 Locale Manager
+ * Manages fake locale transitions.
+ */
+export function setLocale(locale) {
+  console.log('locale set', locale);
+}

--- a/site/agent03/lib/streamAgent.js
+++ b/site/agent03/lib/streamAgent.js
@@ -1,0 +1,8 @@
+/**
+ * Agent 03 Stream Agent
+ * Handles ephemeral streaming connectors.
+ */
+export class StreamAgent {
+  start() {}
+  stop() {}
+}

--- a/site/agent03/security/secureSocket.js
+++ b/site/agent03/security/secureSocket.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 Secure Socket
+ * Placeholder for encrypted channel negotiation.
+ */
+export function openSecureChannel() {
+  return true;
+}

--- a/site/agent03/utils/debugTool.js
+++ b/site/agent03/utils/debugTool.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 Debug Tool
+ * Logs placeholder diagnostics for latency tracking.
+ */
+export function logDebug(msg) {
+  console.log('debug:', msg);
+}

--- a/site/agent03/utils/latencyGauge.js
+++ b/site/agent03/utils/latencyGauge.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 03 Latency Gauge
+ * Measures pseudo-latency for network calls.
+ */
+export function gauge() {
+  return 0;
+}

--- a/site/agent04/config/buildMetadata.js
+++ b/site/agent04/config/buildMetadata.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 04 Build Metadata
+ * Stores compile-time information for debugging.
+ */
+export const BUILD = { id: 'A04' };

--- a/site/agent04/core/pipelineBinder.js
+++ b/site/agent04/core/pipelineBinder.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Pipeline Binder
+ * Connects mocked transformation pipeline stages.
+ */
+export function bindPipeline(stages) {
+  return stages;
+}

--- a/site/agent04/core/versionSwitch.js
+++ b/site/agent04/core/versionSwitch.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Version Switch
+ * Helps switch between stub versions of modules.
+ */
+export function switchVersion(name) {
+  // Placeholder for version toggling
+}

--- a/site/agent04/features/paymentPortal.js
+++ b/site/agent04/features/paymentPortal.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Payment Portal
+ * Placeholder for payment interactions.
+ */
+export function startPayment() {
+  // Payment stub
+}

--- a/site/agent04/features/recommendationUnit.js
+++ b/site/agent04/features/recommendationUnit.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Recommendation Unit
+ * Generates pseudo recommendations for content.
+ */
+export function recommend(item) {
+  return [item];
+}

--- a/site/agent04/lib/dispatchCore.js
+++ b/site/agent04/lib/dispatchCore.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Dispatch Core
+ * Central dispatch for mock events.
+ */
+export function dispatch(event) {
+  // No real dispatching
+}

--- a/site/agent04/lib/statefulRouter.js
+++ b/site/agent04/lib/statefulRouter.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Stateful Router
+ * Simulated router with basic state handling.
+ */
+export function navigate(route) {
+  console.log('navigate:', route);
+}

--- a/site/agent04/security/policyGuard.js
+++ b/site/agent04/security/policyGuard.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Policy Guard
+ * Evaluates dummy security policies.
+ */
+export function checkPolicy() {
+  return true;
+}

--- a/site/agent04/utils/hookResolver.js
+++ b/site/agent04/utils/hookResolver.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 04 Hook Resolver
+ * Locates mock lifecycle hooks for modules.
+ */
+export function resolveHook(name) {
+  return `hook-${name}`;
+}

--- a/site/agent04/utils/tokenQueue.js
+++ b/site/agent04/utils/tokenQueue.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 04 Token Queue
+ * Queues placeholder auth tokens.
+ */
+export const tokenQueue = [];

--- a/site/agent05/config/featureToggles.js
+++ b/site/agent05/config/featureToggles.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 05 Feature Toggles
+ * Stores toggle flags for features.
+ */
+export const toggles = {};

--- a/site/agent05/core/coreGateway.js
+++ b/site/agent05/core/coreGateway.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 05 Core Gateway
+ * Acts as the main entry point for modules.
+ */
+export function gateway() {}

--- a/site/agent05/core/schemaLinker.js
+++ b/site/agent05/core/schemaLinker.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 05 Schema Linker
+ * Links placeholder schemas for data validation.
+ */
+export function linkSchema(schema) {
+  return schema;
+}

--- a/site/agent05/features/dynamicRenderer.js
+++ b/site/agent05/features/dynamicRenderer.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 05 Dynamic Renderer
+ * Renders elements using placeholder templates.
+ */
+export function render() {}

--- a/site/agent05/features/profileBadge.js
+++ b/site/agent05/features/profileBadge.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 05 Profile Badge
+ * Creates stub badges for user profiles.
+ */
+export const badge = 'stub';

--- a/site/agent05/lib/cryptoAdapter.js
+++ b/site/agent05/lib/cryptoAdapter.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 05 Crypto Adapter
+ * Placeholder adapter for crypto operations.
+ */
+export function encrypt(data) {
+  return data;
+}

--- a/site/agent05/lib/logAccumulator.js
+++ b/site/agent05/lib/logAccumulator.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 05 Log Accumulator
+ * Gathers logs for later analysis.
+ */
+export const logs = [];

--- a/site/agent05/security/hashMerkle.js
+++ b/site/agent05/security/hashMerkle.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 05 Hash Merkle
+ * Placeholder for Merkle hash operations.
+ */
+export function buildMerkle() {}

--- a/site/agent05/utils/hashMixer.js
+++ b/site/agent05/utils/hashMixer.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 05 Hash Mixer
+ * Produces deterministic hashes with no security.
+ */
+export function mixHash(input) {
+  return `${input}-mix`;
+}

--- a/site/agent05/utils/syncBarrier.js
+++ b/site/agent05/utils/syncBarrier.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 05 Sync Barrier
+ * Coordinates pseudo-sync operations.
+ */
+export function barrier() {}

--- a/site/agent06/config/runtimeOptions.js
+++ b/site/agent06/config/runtimeOptions.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 06 Runtime Options
+ * Stores runtime configuration stubs.
+ */
+export const options = {};

--- a/site/agent06/core/connectionPool.js
+++ b/site/agent06/core/connectionPool.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 06 Connection Pool
+ * Pretends to manage network connections.
+ */
+export function acquire() {}

--- a/site/agent06/core/healthMonitor.js
+++ b/site/agent06/core/healthMonitor.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 06 Health Monitor
+ * Provides dummy health check utilities.
+ */
+export function check() {
+  return 'ok';
+}

--- a/site/agent06/features/alertModule.js
+++ b/site/agent06/features/alertModule.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 06 Alert Module
+ * Shows placeholder alerts to the user.
+ */
+export function alertUser(msg) {
+  console.log('alert:', msg);
+}

--- a/site/agent06/features/loggingWidget.js
+++ b/site/agent06/features/loggingWidget.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 06 Logging Widget
+ * Displays logs on screen for debugging.
+ */
+export function draw() {}

--- a/site/agent06/lib/apiTranslator.js
+++ b/site/agent06/lib/apiTranslator.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 06 API Translator
+ * Converts placeholder API calls.
+ */
+export function translate() {}

--- a/site/agent06/lib/stateProxy.js
+++ b/site/agent06/lib/stateProxy.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 06 State Proxy
+ * Mocks state access across modules.
+ */
+export const state = {};

--- a/site/agent06/security/encryptionSeal.js
+++ b/site/agent06/security/encryptionSeal.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 06 Encryption Seal
+ * Placeholder encryption wrapper.
+ */
+export function seal(data) {
+  return data;
+}

--- a/site/agent06/utils/dataWrapper.js
+++ b/site/agent06/utils/dataWrapper.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 06 Data Wrapper
+ * Wraps payload data for test flows.
+ */
+export function wrap(data) {
+  return { data };
+}

--- a/site/agent06/utils/flagManager.js
+++ b/site/agent06/utils/flagManager.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 06 Flag Manager
+ * Controls stub flags across modules.
+ */
+export const flags = new Set();

--- a/site/agent07/config/loadBalancer.js
+++ b/site/agent07/config/loadBalancer.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 07 Load Balancer
+ * Handles pseudo-load distribution.
+ */
+export const BALANCER = {};

--- a/site/agent07/core/commandRelay.js
+++ b/site/agent07/core/commandRelay.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 07 Command Relay
+ * Passes commands to worker pools.
+ */
+export function relay(cmd) {
+  return cmd;
+}

--- a/site/agent07/core/lifecycleHook.js
+++ b/site/agent07/core/lifecycleHook.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 07 Lifecycle Hook
+ * Calls hooks at predetermined times.
+ */
+export function runHooks() {}

--- a/site/agent07/features/intelDashboard.js
+++ b/site/agent07/features/intelDashboard.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 07 Intel Dashboard
+ * Displays analytics from test data.
+ */
+export function show() {}

--- a/site/agent07/features/voiceAssistant.js
+++ b/site/agent07/features/voiceAssistant.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 07 Voice Assistant
+ * Stubs voice control features.
+ */
+export function listen() {}

--- a/site/agent07/lib/crudAdapter.js
+++ b/site/agent07/lib/crudAdapter.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 07 CRUD Adapter
+ * Simplifies fake database operations.
+ */
+export function save(item) {
+  return item;
+}

--- a/site/agent07/lib/requestFaker.js
+++ b/site/agent07/lib/requestFaker.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 07 Request Faker
+ * Forges HTTP request objects for tests.
+ */
+export function fakeRequest(url) {
+  return { url };
+}

--- a/site/agent07/security/packetMonitor.js
+++ b/site/agent07/security/packetMonitor.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 07 Packet Monitor
+ * Watches packets for anomalies.
+ */
+export function monitor() {}

--- a/site/agent07/utils/bufferQueue.js
+++ b/site/agent07/utils/bufferQueue.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 07 Buffer Queue
+ * Demonstrates a ring buffer for packets.
+ */
+export const queue = [];

--- a/site/agent07/utils/eventHopper.js
+++ b/site/agent07/utils/eventHopper.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 07 Event Hopper
+ * Serves as a catch-all event buffer.
+ */
+export function hop(event) {
+  queue.push(event);
+}

--- a/site/agent08/config/cacheMatrix.js
+++ b/site/agent08/config/cacheMatrix.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 08 Cache Matrix
+ * Maps resources for caching strategies.
+ */
+export const matrix = {};

--- a/site/agent08/core/rolloutManager.js
+++ b/site/agent08/core/rolloutManager.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 08 Rollout Manager
+ * Coordinates staged deployments for demos.
+ */
+export function rollout() {}

--- a/site/agent08/core/signalBroker.js
+++ b/site/agent08/core/signalBroker.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 08 Signal Broker
+ * Routes mock signals to modules.
+ */
+export function sendSignal() {}

--- a/site/agent08/features/adProcessor.js
+++ b/site/agent08/features/adProcessor.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 08 Ad Processor
+ * Handles pseudo-ad requests.
+ */
+export function processAd() {}

--- a/site/agent08/features/reportLauncher.js
+++ b/site/agent08/features/reportLauncher.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 08 Report Launcher
+ * Launches placeholder reports for admins.
+ */
+export function launch() {}

--- a/site/agent08/lib/dataCloner.js
+++ b/site/agent08/lib/dataCloner.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 08 Data Cloner
+ * Clones data objects for isolation tests.
+ */
+export function clone(item) {
+  return JSON.parse(JSON.stringify(item));
+}

--- a/site/agent08/lib/notificationStub.js
+++ b/site/agent08/lib/notificationStub.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 08 Notification Stub
+ * Emits fake notifications for UI.
+ */
+export function send(note) {
+  console.log('notify', note);
+}

--- a/site/agent08/security/cipherForge.js
+++ b/site/agent08/security/cipherForge.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 08 Cipher Forge
+ * Dummy cipher generation.
+ */
+export function forge() {}

--- a/site/agent08/utils/metricGauge.js
+++ b/site/agent08/utils/metricGauge.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 08 Metric Gauge
+ * Reads placeholder throughput metrics.
+ */
+export function readMetric() {
+  return 0;
+}

--- a/site/agent08/utils/taskLimiter.js
+++ b/site/agent08/utils/taskLimiter.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 08 Task Limiter
+ * Restricts task concurrency in tests.
+ */
+export function limitTasks() {}

--- a/site/agent09/config/accessCatalog.js
+++ b/site/agent09/config/accessCatalog.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Access Catalog
+ * Contains stub ACL definitions.
+ */
+export const catalog = {};

--- a/site/agent09/core/entityLinker.js
+++ b/site/agent09/core/entityLinker.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Entity Linker
+ * Links related entities in the dataset.
+ */
+export function link() {}

--- a/site/agent09/core/streamTracker.js
+++ b/site/agent09/core/streamTracker.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Stream Tracker
+ * Monitors pseudo-stream positions.
+ */
+export function track() {}

--- a/site/agent09/features/deviceBoard.js
+++ b/site/agent09/features/deviceBoard.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Device Board
+ * Lists devices for monitoring.
+ */
+export const devices = [];

--- a/site/agent09/features/metricTrainer.js
+++ b/site/agent09/features/metricTrainer.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Metric Trainer
+ * Trains metrics for sample data.
+ */
+export function train() {}

--- a/site/agent09/lib/jobQueue.js
+++ b/site/agent09/lib/jobQueue.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Job Queue
+ * Stores queued jobs for immediate execution.
+ */
+export const queue = [];

--- a/site/agent09/lib/logParser.js
+++ b/site/agent09/lib/logParser.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 09 Log Parser
+ * Parses stub log entries.
+ */
+export function parse(log) {
+  return { log };
+}

--- a/site/agent09/security/vaultEntry.js
+++ b/site/agent09/security/vaultEntry.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Vault Entry
+ * Handles placeholder secrets.
+ */
+export const vault = {};

--- a/site/agent09/utils/scriptPreloader.js
+++ b/site/agent09/utils/scriptPreloader.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Script Preloader
+ * Preloads dummy scripts for performance tests.
+ */
+export function preload() {}

--- a/site/agent09/utils/streamValve.js
+++ b/site/agent09/utils/streamValve.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 09 Stream Valve
+ * Controls pseudo-stream throughput.
+ */
+export function open() {}

--- a/site/agent10/config/alphaKeys.js
+++ b/site/agent10/config/alphaKeys.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 10 Alpha Keys
+ * Stores test API keys.
+ */
+export const KEYS = [];

--- a/site/agent10/core/registryNode.js
+++ b/site/agent10/core/registryNode.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 10 Registry Node
+ * Registers components for the app.
+ */
+export const registry = new Map();

--- a/site/agent10/core/sequenceDriver.js
+++ b/site/agent10/core/sequenceDriver.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 10 Sequence Driver
+ * Drives sequential execution for modules.
+ */
+export function drive(seq) {
+  seq.forEach(fn => fn());
+}

--- a/site/agent10/features/insightWidget.js
+++ b/site/agent10/features/insightWidget.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 10 Insight Widget
+ * Provides stub insights for dashboards.
+ */
+export function renderInsight() {}

--- a/site/agent10/features/routingAssistant.js
+++ b/site/agent10/features/routingAssistant.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 10 Routing Assistant
+ * Helps with navigation hints.
+ */
+export function assist() {}

--- a/site/agent10/lib/frameBinder.js
+++ b/site/agent10/lib/frameBinder.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 10 Frame Binder
+ * Connects frames for stub navigation.
+ */
+export function bindFrame(frame) {
+  return frame;
+}

--- a/site/agent10/lib/sessionMapper.js
+++ b/site/agent10/lib/sessionMapper.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 10 Session Mapper
+ * Maps session info for tests.
+ */
+export function mapSession(id) {
+  return { id };
+}

--- a/site/agent10/security/signatureBoard.js
+++ b/site/agent10/security/signatureBoard.js
@@ -1,0 +1,5 @@
+/**
+ * Agent 10 Signature Board
+ * Maintains placeholder digital signatures.
+ */
+export const signatures = [];

--- a/site/agent10/utils/errorMirror.js
+++ b/site/agent10/utils/errorMirror.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 10 Error Mirror
+ * Reflects errors for diagnostics.
+ */
+export function mirror(error) {
+  return error;
+}

--- a/site/agent10/utils/tokenHydrator.js
+++ b/site/agent10/utils/tokenHydrator.js
@@ -1,0 +1,7 @@
+/**
+ * Agent 10 Token Hydrator
+ * Hydrates tokens with mock claims.
+ */
+export function hydrate(token) {
+  return { token };
+}


### PR DESCRIPTION
## Summary
- add 100 inert JS modules inside `site` under agent folders
- update `AGENT_LOG.md` with timestamped note

## Testing
- `serve site` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558f13d8708333859b5cbeb9e60623