### PR TITLE
Add package.json for buildpack detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fourth-down-decider",
+  "version": "1.0.0",
+  "description": "A static website for exploring football fourth down decisions.",
+  "scripts": {
+    "start": "serve -s site -l $PORT"
+  },
+  "dependencies": {
+    "serve": "^14.2.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` declaring `serve` dependency so node buildpacks detect the project

## Testing
- `npm install -g serve`
- `serve site -l 3000`

------
https://chatgpt.com/codex/tasks/task_e_6855d398500483338c81b7e7233b2635