### PR TITLE
Persist slider setting with localStorage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -11,7 +11,7 @@
         <h1>Fourth Down Decision Helper</h1>
         <label for="distanceRange">Distance to First Down (1-15 yards):</label>
         <input type="range" id="distanceRange" min="1" max="15" value="1">
-        <span id="distanceValue">1</span> yards
+        <span id="distanceValue"></span> yards
         <button id="decideBtn">Get Decision</button>
         <div id="output" class="output"></div>
     </div>

--- a/site/script.js
+++ b/site/script.js
@@ -28,5 +28,25 @@ function updateDecision() {
     }
 }
 
-document.getElementById('distanceRange').addEventListener('input', updateDecision);
+const rangeEl = document.getElementById('distanceRange');
+
+rangeEl.addEventListener('input', () => {
+    localStorage.setItem('distanceRange', rangeEl.value);
+    updateDecision();
+});
+
 document.getElementById('decideBtn').addEventListener('click', updateDecision);
+
+document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('reset') === 'true') {
+        localStorage.removeItem('distanceRange');
+    }
+
+    const saved = localStorage.getItem('distanceRange');
+    if (saved !== null) {
+        rangeEl.value = saved;
+    }
+
+    updateDecision();
+});


### PR DESCRIPTION
## Summary
- save slider value to localStorage whenever it changes
- initialize slider from saved setting on page load
- clear saved value when `?reset=true`
- remove default distance display in HTML so JS fills it

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `python3 features/testHarness.py`

------
https://chatgpt.com/codex/tasks/task_e_6855d47514e483339f7cfcfd913f269b